### PR TITLE
Add source-code save to local storage

### DIFF
--- a/editor.bundle.js
+++ b/editor.bundle.js
@@ -26379,6 +26379,7 @@ const setupEditor = function() {
       { 
         key: "Ctrl-Enter", 
         run(e) { 
+          localStorage.setItem("src", e.state.doc.toString())
           runGraphics( shaderInit( e.state.doc.toString() ) );
           return true
         } 
@@ -26386,8 +26387,11 @@ const setupEditor = function() {
     ])
   );
 
+  let src = localStorage.getItem("src")
+  src = src == null ? shaderDefault : src
+
   window.editor = new EditorView({
-    doc: shaderDefault,
+    doc: src,
     extensions: [
       basicSetup, 
       wgsl(),

--- a/main.js
+++ b/main.js
@@ -97,15 +97,19 @@ const setupEditor = function() {
       { 
         key: "Ctrl-Enter", 
         run(e) { 
-          runGraphics( shaderInit( e.state.doc.toString() ) )
+          localStorage.setItem("src", e.state.doc.toString())
+          runGraphics( shaderInit( e.state.doc.toString() ) );
           return true
         } 
       }
     ])
-  )
+  );
+
+  let src = localStorage.getItem("src")
+  src = src == null ? shaderDefault : src
 
   window.editor = new EditorView({
-    doc: shaderDefault,
+    doc: src,
     extensions: [
       basicSetup, 
       wgsl(),
@@ -113,10 +117,10 @@ const setupEditor = function() {
       basicDark
     ],
     parent: document.body,
-  })
+  });
 
-  editor.focus()
-}
+  editor.focus();
+};
 
 let mousex = 0, mousey = 0, mouseclick = 0
 const setupMouse = function() {


### PR DESCRIPTION
I noticed that whenever I reloaded the page (or, if the page crashes), the source code I was working on would be reset, so I just added a feature that automatically saves your current source code to browser storage whenever you hit Ctrl+Enter to refresh the shader.